### PR TITLE
Add detailed availability toggle for richer commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains an unpacked Chromium extension that adds a “*I” cop
 5. Select the folder that contains `manifest.json`.
 
 Once loaded, open the popup to adjust booking class or segment status defaults.
+You can also enable the **Detailed availability search** toggle to include departure
+times and layover minutes in copied availability commands.
 
 ## Development
 

--- a/converter.test.js
+++ b/converter.test.js
@@ -459,4 +459,40 @@ const multiCarrierItinerary = [
 const multiCarrierAvailability = window.convertTextToAvailability(multiCarrierItinerary, { direction: 'outbound' });
 assert.strictEqual(multiCarrierAvailability, '112JUNIADNBO12ACPH/AMS¥SK¥KQ¥KQ', 'availability should list each marketing carrier sequentially');
 
+const detailedAvailabilitySample = [
+  'Depart • Wed, Nov 13',
+  'Turkish Airlines 272',
+  '9:35 pm',
+  'Chișinău Intl (RMO)',
+  '12:15 am',
+  'Istanbul (IST)',
+  'Arrives Thu, Nov 14',
+  'Turkish Airlines 44',
+  '1:55 am',
+  'Istanbul (IST)',
+  '11:50 am',
+  'Cape Town (CPT)',
+  'Return • Tue, Nov 26',
+  'Turkish Airlines 45',
+  '5:15 pm',
+  'Cape Town (CPT)',
+  '5:35 am',
+  'Istanbul (IST)',
+  'Arrives Wed, Nov 27',
+  'Turkish Airlines 271',
+  '8:15 pm',
+  'Istanbul (IST)',
+  '8:45 pm',
+  'Chișinău Intl (RMO)'
+].join('\n');
+
+const detailedAvailabilityBasic = window.convertTextToAvailability(detailedAvailabilitySample, { direction: 'outbound' });
+assert.strictEqual(detailedAvailabilityBasic, '113NOVRMOCPT12AIST¥TK¥TK', 'baseline availability should retain legacy format when detailed mode is off');
+
+const detailedAvailabilityEnhanced = window.convertTextToAvailability(detailedAvailabilitySample, {
+  direction: 'outbound',
+  detailed: true
+});
+assert.strictEqual(detailedAvailabilityEnhanced, '113NOVRMOCPT935PIST-100¥TK¥TK', 'detailed availability should include departure time and layover minutes');
+
 console.log('✓ converter maintains departure date continuity for connecting segments');

--- a/popup.html
+++ b/popup.html
@@ -472,6 +472,11 @@
         <span class="toggle__label">Show availability buttons</span>
       </label>
       <p class="toggle-help">Adds outbound / inbound (and multi-city journey) availability pills next to *I.</p>
+      <label class="toggle" for="detailedAvailability">
+        <input id="detailedAvailability" type="checkbox" />
+        <span class="toggle__label">Detailed availability search</span>
+      </label>
+      <p class="toggle-help">Include departure times and layover minutes in availability commands.</p>
       <div class="card__actions">
         <button id="saveBtn" type="button" class="btn btn-primary">Save preferences</button>
         <span id="ok" class="status-pill">Saved</span>


### PR DESCRIPTION
## Summary
- add a popup toggle so users can enable detailed availability search formatting
- plumb the detailed availability flag through popup, content, and converter logic to include departure times and layover minutes
- extend unit tests and documentation to cover the richer availability output

## Testing
- node converter.test.js
- node popup.convert.test.js
- node rbd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1a11e9de483269d0498e656c5c7be