### PR TITLE
Fix midnight arrival formatting and preserve rolled dates

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -881,13 +881,22 @@
         }
       }
       if(referenceDate){
-        const prevDow = currentDate ? currentDate.dow : '';
-        const nextDow = referenceDate.dow || prevDow || '';
-        currentDate = {
-          day: referenceDate.day,
-          mon: referenceDate.mon,
-          dow: nextDow
-        };
+        let shouldOverrideCurrent = true;
+        if(currentDate){
+          const diff = dateInfoDifferenceInDays(currentDate, referenceDate);
+          if(diff != null && diff < 0){
+            shouldOverrideCurrent = false;
+          }
+        }
+        if(shouldOverrideCurrent){
+          const prevDow = currentDate ? currentDate.dow : '';
+          const nextDow = referenceDate.dow || prevDow || '';
+          currentDate = {
+            day: referenceDate.day,
+            mon: referenceDate.mon,
+            dow: nextDow
+          };
+        }
       }
 
       for(; k < lines.length; k++){
@@ -1138,6 +1147,9 @@
     const formatGdsTime = (value) => {
       if(!value) return '';
       const trimmed = String(value).trim();
+      if(/^00(\d{2}[AP])$/i.test(trimmed)){
+        return trimmed.replace(/^00/, '12');
+      }
       return trimmed.replace(/^0+(\d)/, '$1');
     };
 

--- a/converter.test.js
+++ b/converter.test.js
@@ -340,6 +340,20 @@ const midnightPeek = window.peekSegments(midnightConnection);
 assert.ok(/04NOV/.test(midnightLines[1] || ''), 'overnight connection should advance to Nov 4 in output');
 assert.strictEqual(midnightPeek.segments[1].depDate, '04NOV', 'overnight connection within a journey should roll to the next day');
 
+const midnightArrivalEncoding = [
+  'Depart • Thu, Nov 13',
+  'Flight 1 • Thu, Nov 13',
+  'Turkish Airlines 272',
+  '9:35 pm',
+  'Chișinău Intl (RMO)',
+  '12:15 am',
+  'Istanbul (IST)',
+  'Arrives Fri, Nov 14'
+].join('\n');
+
+const midnightArrivalLines = window.convertTextToI(midnightArrivalEncoding);
+assert.ok(/1215A/.test(midnightArrivalLines), 'overnight arrival should encode 12:15 AM as 1215A');
+
 const kayakSplitHeader = [
   'Depart',
   '23h 15m',


### PR DESCRIPTION
## Summary
- prevent itinerary parsing from rewinding the working date when a flight header repeats an earlier day
- normalize midnight GDS times to emit 12xxA so midnight arrivals show correctly in copy output
- cover the midnight formatting regression with a converter unit test

## Testing
- node converter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a6a7a654832685ab377b49f78fa5