### PR TITLE
Fix detailed availability layover rollover

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -2065,7 +2065,7 @@
     const monthOffset = MONTH_DAY_OFFSETS[monthIndex] != null ? MONTH_DAY_OFFSETS[monthIndex] : (monthIndex * 31);
     let ordinal = monthOffset + dayValue;
     if(prevOrdinal != null){
-      while(ordinal <= prevOrdinal){
+      while(ordinal < prevOrdinal){
         ordinal += ORDINAL_YEAR_SPAN;
       }
     }

--- a/converter.test.js
+++ b/converter.test.js
@@ -565,4 +565,40 @@ const detailedAvailabilityEnhanced = window.convertTextToAvailability(detailedAv
 });
 assert.strictEqual(detailedAvailabilityEnhanced, '113NOVRMOCPT935PIST-100¥TK¥TK', 'detailed availability should include departure time and layover minutes');
 
+const tapPortugalSample = [
+  'Depart • Tue, Nov 19',
+  'TAP Portugal 244',
+  '7:10 pm',
+  'Chicago (ORD)',
+  '9:05 am',
+  'Lisbon (LIS)',
+  'Arrives Wed, Nov 20',
+  'TAP Portugal 572',
+  '12:45 pm',
+  'Lisbon (LIS)',
+  '4:55 pm',
+  'Frankfurt (FRA)',
+  'Return • Sat, Dec 7',
+  'TAP Portugal 575',
+  '6:00 am',
+  'Frankfurt (FRA)',
+  '8:15 am',
+  'Lisbon (LIS)',
+  'TAP Portugal 243',
+  '11:10 am',
+  'Lisbon (LIS)',
+  '2:45 pm',
+  'Chicago (ORD)'
+].join('\n');
+
+const tapPortugalDetailedInbound = window.convertTextToAvailability(tapPortugalSample, {
+  direction: 'inbound',
+  detailed: true
+});
+assert.strictEqual(
+  tapPortugalDetailedInbound,
+  '17DECFRAORD600ALIS-175¥TP¥TP',
+  'detailed availability should keep same-day layovers within the current year'
+);
+
 console.log('✓ converter maintains departure date continuity for connecting segments');


### PR DESCRIPTION
## Summary
- stop the ordinal date helper from rolling same-day segments into the next year in detailed availability mode
- add a TAP Portugal regression test that verifies the layover minutes on the inbound detailed availability command

## Testing
- node converter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4240d6d7883269eeac9a6e70fcf7e