### PR TITLE
Adjust RBD defaults for TK/SK and short-haul First

### DIFF
--- a/content.js
+++ b/content.js
@@ -841,7 +841,9 @@
     const getPreferred = (typeof window !== 'undefined' && typeof window.getPreferredRBD === 'function')
       ? window.getPreferredRBD
       : null;
-    let bookingClass = getPreferred ? getPreferred('', cabinEnum) : null;
+    let bookingClass = getPreferred
+      ? getPreferred({ airlineCode: '', marketedCabin: cabinEnum, durationMinutes: null })
+      : null;
     if(!bookingClass){
       bookingClass = CABIN_DEFAULT_BOOKING[cabinEnum] || null;
     }

--- a/converter.js
+++ b/converter.js
@@ -1182,7 +1182,18 @@
       if(!bookingClass){
         if(preferredRbdFn && autoCabinEnum){
           try {
-            const candidate = preferredRbdFn(s ? s.airlineCode || '' : '', autoCabinEnum);
+            const durationMinutes = (() => {
+              if (!s) return null;
+              if (Number.isFinite(s.durationMinutes)) return s.durationMinutes;
+              if (Number.isFinite(s.elapsedMinutes)) return s.elapsedMinutes;
+              if (Number.isFinite(s.elapsedHours)) return Math.round(s.elapsedHours * 60);
+              return null;
+            })();
+            const candidate = preferredRbdFn({
+              airlineCode: s ? s.airlineCode || '' : '',
+              marketedCabin: autoCabinEnum,
+              durationMinutes
+            });
             if(candidate){
               bookingClass = String(candidate).trim().toUpperCase();
             }

--- a/rbd.test.js
+++ b/rbd.test.js
@@ -12,35 +12,51 @@ function test(description, fn){
 }
 
 test('LH + BUSINESS → J', () => {
-  assert.strictEqual(getPreferredRBD('LH', 'BUSINESS'), 'J');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'LH', marketedCabin: 'BUSINESS', durationMinutes: 480 }), 'J');
 });
 
 test('AA + BUSINESS → J', () => {
-  assert.strictEqual(getPreferredRBD('AA', 'BUSINESS'), 'J');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'AA', marketedCabin: 'BUSINESS', durationMinutes: 180 }), 'J');
 });
 
 test('TP + BUSINESS → C', () => {
-  assert.strictEqual(getPreferredRBD('TP', 'BUSINESS'), 'C');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'TP', marketedCabin: 'BUSINESS', durationMinutes: 300 }), 'C');
 });
 
 test('DL + PREMIUM → P', () => {
-  assert.strictEqual(getPreferredRBD('DL', 'PREMIUM'), 'P');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'DL', marketedCabin: 'PREMIUM', durationMinutes: 200 }), 'P');
 });
 
 test('UA + ECONOMY → Y', () => {
-  assert.strictEqual(getPreferredRBD('UA', 'ECONOMY'), 'Y');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'UA', marketedCabin: 'ECONOMY', durationMinutes: 150 }), 'Y');
 });
 
 test('BA + FIRST → F', () => {
-  assert.strictEqual(getPreferredRBD('BA', 'FIRST'), 'F');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'BA', marketedCabin: 'FIRST', durationMinutes: 600 }), 'F');
 });
 
 test('Unknown airline ZZ + BUSINESS → J (generic)', () => {
-  assert.strictEqual(getPreferredRBD('ZZ', 'BUSINESS'), 'J');
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'ZZ', marketedCabin: 'BUSINESS', durationMinutes: 90 }), 'J');
 });
 
 test('Airline without FIRST cabin returns null', () => {
-  assert.strictEqual(getPreferredRBD('B6', 'FIRST'), null);
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'B6', marketedCabin: 'FIRST', durationMinutes: 480 }), null);
+});
+
+test('TK business uses C', () => {
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'TK', marketedCabin: 'BUSINESS', durationMinutes: 480 }), 'C');
+});
+
+test('SK business uses C', () => {
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'SK', marketedCabin: 'BUSINESS', durationMinutes: 120 }), 'C');
+});
+
+test('Short-haul First converts to Business', () => {
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'AA', marketedCabin: 'FIRST', durationMinutes: 220 }), 'J');
+});
+
+test('Long-haul First stays First', () => {
+  assert.strictEqual(getPreferredRBD({ airlineCode: 'AA', marketedCabin: 'FIRST', durationMinutes: 420 }), 'F');
 });
 
 test('normalizeCabinEnum handles lowercase business', () => {


### PR DESCRIPTION
## Summary
- update airline RBD tables and selection logic so TK and SK business cabins default to C and short-haul First (≤6h) is treated as Business
- propagate the new getPreferredRBD signature to callers, forwarding segment durations where available and aligning popup heuristics
- expand unit coverage for the revised booking-class selection scenarios

## Testing
- node rbd.test.js
- node converter.test.js
- node popup.convert.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e42c3239748326bdd3d06db54af0ff