### PR TITLE
Handle Gulf Air itinerary parsing with parenthetical codes

### DIFF
--- a/airlines.js
+++ b/airlines.js
@@ -448,13 +448,30 @@ Object.keys(AIRLINE_CODES).forEach((key) => {
 
 function lookupAirlineCodeByName(name){
     if(!name && name !== 0) return null;
-    const directKey = String(name).trim().toUpperCase();
+    const rawValue = String(name);
+    const directKey = rawValue.trim().toUpperCase();
     if(directKey && Object.prototype.hasOwnProperty.call(AIRLINE_CODES, directKey)){
         return AIRLINE_CODES[directKey];
+    }
+    const parentheticalStripped = rawValue
+        .replace(/\((?:[A-Z0-9]{1,3})\)/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    if(parentheticalStripped){
+        const parentheticalKey = parentheticalStripped.toUpperCase();
+        if(parentheticalKey !== directKey && Object.prototype.hasOwnProperty.call(AIRLINE_CODES, parentheticalKey)){
+            return AIRLINE_CODES[parentheticalKey];
+        }
     }
     const normalized = normalizeAirlineNameKey(name);
     if(normalized && Object.prototype.hasOwnProperty.call(AIRLINE_NORMALIZED_CODES, normalized)){
         return AIRLINE_NORMALIZED_CODES[normalized];
+    }
+    if(parentheticalStripped){
+        const normalizedStripped = normalizeAirlineNameKey(parentheticalStripped);
+        if(normalizedStripped && Object.prototype.hasOwnProperty.call(AIRLINE_NORMALIZED_CODES, normalizedStripped)){
+            return AIRLINE_NORMALIZED_CODES[normalizedStripped];
+        }
     }
     return null;
 }

--- a/converter.js
+++ b/converter.js
@@ -441,7 +441,8 @@
       .trim();
     if(!cleaned) return null;
     if(isLikelyEquipmentLine(cleaned)) return null;
-    const m = cleaned.match(/^([A-Za-z][A-Za-z\s'&.-]*?)\s+(\d{1,4})\b/);
+    const airlineTokenSanitized = cleaned.replace(/\((?:[A-Z0-9]{1,3})\)\s*(?=\d)/g, ' ');
+    const m = airlineTokenSanitized.match(/^([A-Za-z][A-Za-z\s'&.-]*?)\s+(\d{1,4})\b/);
     if(!m) return null;
     const airlineName = m[1].trim();
     if(/\bOPERATED BY\b/i.test(airlineName)) return null;

--- a/converter.test.js
+++ b/converter.test.js
@@ -601,4 +601,27 @@ assert.strictEqual(
   'detailed availability should keep same-day layovers within the current year'
 );
 
+const gulfAirSample = [
+  'Depart • Wed, Nov 19',
+  'Gulf Air (GF) 90',
+  '11:55 am',
+  'New York John F Kennedy Intl (JFK)',
+  '12h 25m',
+  'Overnight flight',
+  '3:20 pm',
+  'Manama Bahrain Intl (BAH)',
+  'Arrives Thu, Nov 20',
+  '1h 45m • Change planes in Manama (BAH)',
+  'Gulf Air (GF) 171',
+  '5:05 pm',
+  'Manama Bahrain Intl (BAH)',
+  '7:55 pm',
+  'Jeddah King Abdulaziz Intl (JED)'
+].join('\n');
+
+const gulfAirLines = window.convertTextToI(gulfAirSample).split('\n');
+assert.strictEqual(gulfAirLines.length, 2, 'Gulf Air itinerary should yield two flight segments');
+assert.ok(/GF 90/.test(gulfAirLines[0]), 'first Gulf Air segment should retain GF 90');
+assert.ok(/GF 171/.test(gulfAirLines[1]), 'second Gulf Air segment should retain GF 171');
+
 console.log('✓ converter maintains departure date continuity for connecting segments');


### PR DESCRIPTION
## Summary
- strip parenthetical carrier codes when looking up airline mappings
- sanitize airline + flight lines so Gulf Air segments parse correctly
- cover the regression with a Gulf Air itinerary test case

## Testing
- node converter.test.js
- node popup.convert.test.js
- node rbd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e53b337e588326ae3114592605e69b